### PR TITLE
Fix Reveal 1.5 'Undefined symbols' build error

### DIFF
--- a/lib/motion-reveal.rb
+++ b/lib/motion-reveal.rb
@@ -5,6 +5,8 @@ end
 Motion::Project::App.setup do |app|
   app.development do
     if File.exist? ('/Applications/Reveal.app')
+      # Fixes build issues with Reveal 1.5
+      app.libs += ['/usr/lib/libz.dylib', '/usr/lib/libc++.dylib']
       app.vendor_project('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/Reveal.framework', :static, :products => ['Reveal'], :cflags => '-ObjC')
       app.frameworks << 'CFNetwork'
       app.frameworks << 'QuartzCore'


### PR DESCRIPTION
Oopsie, accidentally deleted a branch.

Fix for Reveal 1.5 build error:

```
Undefined symbols for architecture i386:
  "_deflate", referenced from:
      -[IBAHTTPJSONResponse initWithJSONString:compress:] in Reveal(IBAHTTPJSONResponse.o)
  "_deflateEnd", referenced from:
      -[IBAHTTPJSONResponse initWithJSONString:compress:] in Reveal(IBAHTTPJSONResponse.o)
  "_deflateInit2_", referenced from:
      -[IBAHTTPJSONResponse initWithJSONString:compress:] in Reveal(IBAHTTPJSONResponse.o)
ld: symbol(s) not found for architecture i386
```
