### PR TITLE
Adding support for Reveal 2.0

### DIFF
--- a/lib/motion-reveal.rb
+++ b/lib/motion-reveal.rb
@@ -7,7 +7,11 @@ Motion::Project::App.setup do |app|
     if File.exist? ('/Applications/Reveal.app')
       # Fixes build issues with Reveal 1.5
       app.libs += ['/usr/lib/libz.dylib', '/usr/lib/libc++.dylib']
-      app.vendor_project('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/Reveal.framework', :static, :products => ['Reveal'], :cflags => '-ObjC')
+      if File.exist?('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/RevealServer.framework') #Reveal 2.0
+        app.embedded_frameworks += ['/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/RevealServer.framework']
+      else
+        app.vendor_project('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/Reveal.framework', :static, :products => ['Reveal'], :cflags => '-ObjC')
+      end
       app.frameworks << 'CFNetwork'
       app.frameworks << 'QuartzCore'
 


### PR DESCRIPTION
Now uses an embedded framework.
Preserved support for previous versions by detecting presence of renamed framework
