### PR TITLE
excluding from fabric build

### DIFF
--- a/lib/motion-reveal.rb
+++ b/lib/motion-reveal.rb
@@ -4,19 +4,21 @@ end
 
 Motion::Project::App.setup do |app|
   app.development do
-    if File.exist? ('/Applications/Reveal.app')
-      # Fixes build issues with Reveal 1.5
-      app.libs += ['/usr/lib/libz.dylib', '/usr/lib/libc++.dylib']
-      if File.exist?('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/RevealServer.framework') #Reveal 2.0
-        app.embedded_frameworks += ['/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/RevealServer.framework']
-      else
-        app.vendor_project('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/Reveal.framework', :static, :products => ['Reveal'], :cflags => '-ObjC')
-      end
-      app.frameworks << 'CFNetwork'
-      app.frameworks << 'QuartzCore'
+    unless  Module.const_defined?(:CRASHLYTICS_BETA)
+      if File.exist? ('/Applications/Reveal.app')
+        # Fixes build issues with Reveal 1.5
+        app.libs += ['/usr/lib/libz.dylib', '/usr/lib/libc++.dylib']
+        if File.exist?('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/RevealServer.framework') #Reveal 2.0
+          app.embedded_frameworks += ['/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/RevealServer.framework']
+        else
+          app.vendor_project('/Applications/Reveal.app/Contents/SharedSupport/iOS-Libraries/Reveal.framework', :static, :products => ['Reveal'], :cflags => '-ObjC')
+        end
+        app.frameworks << 'CFNetwork'
+        app.frameworks << 'QuartzCore'
 
-    else
-      puts "[warning] Reveal.app not found - Download beta from http://www.revealapp.com"
+      else
+        puts "[warning] Reveal.app not found - Download beta from http://www.revealapp.com"
+      end
     end
   end
 end

--- a/motion-reveal.gemspec
+++ b/motion-reveal.gemspec
@@ -1,12 +1,18 @@
-Gem::Specification.new do |gem|
-  gem.authors     = ["Diogo"]
-  gem.email       = 'diogo@regattapix.com'
-  gem.name        = 'motion-reveal'
-  gem.summary     = "Use Reveal in RubyMotion apps"
-  gem.description = "Just a simple gem to add the Reval framework to your RubyMotion project."
-  gem.version     = '1.0.0'
-  gem.date        = '2013-06-05'
-  gem.homepage    = 'https://github.com/diogoandre/motion-reveal'
+# -*- encoding: utf-8 -*-
+# stub: motion-reveal 1.0.0 ruby lib
 
-  gem.files       = ["lib/motion-reveal.rb"]
+Gem::Specification.new do |s|
+  s.name = "motion-reveal"
+  s.version = "1.0.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Diogo"]
+  s.date = "2013-06-05"
+  s.description = "Just a simple gem to add the Reval framework to your RubyMotion project."
+  s.email = "diogo@regattapix.com"
+  s.files = ["lib/motion-reveal.rb"]
+  s.homepage = "https://github.com/diogoandre/motion-reveal"
+  s.rubygems_version = "2.4.8"
+  s.summary = "Use Reveal in RubyMotion apps"
 end


### PR DESCRIPTION
I noticed that under ios 10.1 beta 3 apps are failing to install due to code signing issues with revealserver.framework. 

So I excluded it ... not sure if you want to mainstream this but it's useful for now.
